### PR TITLE
BugFix in delete

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -140,7 +140,7 @@ void delsave(string & mode) {
         cout << "No player saves found, please enter 0 for new save or enter 3 to "
                 "quit: ";
         std::cin >> mode;
-        while (mode != "0" && mode != "1" && mode != "3") {
+        while (mode != "0" && mode != "3") {
             std::cout
                 << "Invalid input. Please enter 0 for new save or enter 3 to quit: ";
             std::cin >> mode; // choose new file or load previous file


### PR DESCRIPTION
Disable players to enter 1 to play without creating playerName folder when they deleted all save