### PR TITLE
Actions: Replace self-hosted runners with github runners

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,14 +7,14 @@ on:
     pull_request:
     workflow_dispatch:
 
-concurrency:
-    group: "clang-format"
-    cancel-in-progress: false
+#concurrency:
+#    group: "clang-format"
+#    cancel-in-progress: false
 
 jobs:
   clang-format:
-    runs-on: self-hosted
-    # runs-on: ubuntu-latest
+    #runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,11 +1,7 @@
 name: clang-format
 
-on:
-    push:
-        branches:
-            - main
-    pull_request:
-    workflow_dispatch:
+on: 
+    [push, workflow_dispatch]
 
 #concurrency:
 #    group: "clang-format"

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -29,14 +29,11 @@ jobs:
     - name: Make test
       run: |
         # test for creating saves
-        echo -e "0\n saves\nsaves\nB\n1\n1\nN\nY\nN\nY\nN\nY\nT\n0\nT\n1\nT\n2\nE\nT\nX\nY\n" > input.txt
-        ./stocksim < input.txt
+        echo -e "0\n saves\nsaves\nB\n1\n1\nN\nY\nN\nY\nN\nY\nT\n0\nT\n1\nT\n2\nE\nT\nX\nY\n" | ./stocksim
         # test for loading saves
-        echo -e "1\nsaves\nN\nY\nN\nY\nN\nY\nN\nY\nT\n0\nT\nT\n3\nT\n4\nT\nS\n1\n1\nX\nY\n" > input.txt
-        ./stocksim < input.txt
+        echo -e "1\nsaves\nN\nY\nN\nY\nN\nY\nN\nY\nT\n0\nT\nT\n3\nT\n4\nT\nS\n1\n1\nX\nY\n" | ./stocksim
         # test for deleting saves
-        echo -e "2\nsaves\nY\n3\n" > input.txt
-        ./stocksim < input.txt
+        echo -e "2\nsaves\nY\n3\n" | ./stocksim
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,8 +2,6 @@ name: Make
 
 on:
     push:
-        branches:
-            - main
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -7,19 +7,19 @@ on:
     pull_request:
     workflow_dispatch:
 
-concurrency:
-    group: "make"
-    cancel-in-progress: false
+#concurrency:
+#    group: "make"
+#    cancel-in-progress: false
 
 jobs:
   Make:
-    runs-on: self-hosted
+    #runs-on: self-hosted
     timeout-minutes: 5
-    #runs-on: ${{ matrix.os }}
-    #strategy:
-    #  fail-fast: true
-    #  matrix:
-    #    os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -37,26 +37,13 @@ jobs:
         # test for deleting saves
         echo -e "2\nsaves\nY\n3\n" > input.txt
         ./stocksim < input.txt
-    - name: Doxygen Documentation
-      if: always()
-      run: |
-        make docs
-        cd latex
-        make 2>/dev/null || true
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
         # suppose we compiled our game and named it 'stocksim'
         # use wildcard to match the executable for all platforms
-        name: stocksim
-        # name: stocksim-${{ matrix.os }}
+        # name: stocksim
+        name: stocksim-${{ matrix.os }}
         path: stocksim*
-        compression-level: 9
-        if-no-files-found: error
-    - name: Upload reference manual
-      uses: actions/upload-artifact@v4
-      with:
-        name: refman
-        path: latex/refman.pdf
         compression-level: 9
         if-no-files-found: error

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         make clean default
     - name: Make test
+      shell: bash
       run: |
         # test for creating saves
         echo -e "0\n saves\nsaves\nB\n1\n1\nN\nY\nN\nY\nN\nY\nT\n0\nT\n1\nT\n2\nE\nT\nX\nY\n" | ./stocksim

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,11 +1,7 @@
 name: Make
 
 on:
-    push:
-      branches:
-        - main
-    pull_request:
-    workflow_dispatch:
+    [push, workflow_dispatch]
 
 #concurrency:
 #    group: "make"
@@ -14,7 +10,7 @@ on:
 jobs:
   Make:
     #runs-on: self-hosted
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,6 +2,8 @@ name: Make
 
 on:
     push:
+      branches:
+        - main
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: Pages (doxygen)
 
 on:
   push:
-  pull_requests:
+  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,10 +2,8 @@
 name: Pages (doxygen)
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
-
+  pull_requests:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -22,23 +20,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install and run doxygen via Chocolatey
+      #- name: Run Doxygen
+        run: |
+          choco install doxygen.portable graphviz --yes -r --no-progress
+          make docs
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     #runs-on: [self-hosted]
     runs-on: windows-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Install and run doxygen via Chocolatey
-      #- name: Run Doxygen
-        run: |
-          choco install doxygen.portable graphviz --yes -r --no-progress
-          make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,17 +27,17 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted]
-    # runs-on: windows-latest
+    #runs-on: [self-hosted]
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      #- name: Install and run doxygen via Chocolatey
-      - name: Run Doxygen
+      - name: Install and run doxygen via Chocolatey
+      #- name: Run Doxygen
         run: |
-          # choco install doxygen.portable graphviz --yes -r --no-progress
+          choco install doxygen.portable graphviz --yes -r --no-progress
           make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,12 +2,7 @@
 name: Pages (doxygen)
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  [push, workflow_dispatch]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,6 +3,8 @@ name: Pages (doxygen)
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Does three things:
- Replace runs-on: self-hosted with github runners, and perform adjustments required by above changes.
- Add back runs-on matrix. It means that we run make test on macos, windows and linux systems.
- Separate build job and deploy job for github pages, so that we can run build job on non-main/pull request branches. I believe this rarely introduce new errors at this time, since we ignore warnings generated by doxygen when generating the documentation.