### PR TITLE
Pages: Build documentation for every branch

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       # Because ubuntu doxygen is currently outdated (v1.9 instead of v1.10)
       - name: Install doxygen and graphviz via Chocolatey
         run: |
@@ -36,6 +38,7 @@ jobs:
           for branch in $(git branch | cut -c 3-)
           do
             echo $branch
+            git checkout $branch
             make clean
             make docs
             mv html docs-output/$branch

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       # Because ubuntu doxygen is currently outdated (v1.9 instead of v1.10)
       - name: Install doxygen and graphviz via Chocolatey
         run: |
@@ -35,7 +33,7 @@ jobs:
         shell: bash
         run: |
           mkdir docs-output
-          for branch in $(git branch | cut -c 3-)
+          for branch in $(git branch -lr | cut -c 10- | cut -d ' ' -f 1 | grep -v HEAD)
           do
             echo $branch
             git checkout $branch

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       # Because ubuntu doxygen is currently outdated (v1.9 instead of v1.10)
       - name: Install doxygen and graphviz via Chocolatey
         run: |
@@ -33,7 +35,8 @@ jobs:
         shell: bash
         run: |
           mkdir docs-output
-          for branch in $(git branch -lr | cut -c 10- | cut -d ' ' -f 1 | grep -v HEAD)
+          branches="`git branch -lr | cut -c 10- | cut -d ' ' -f 1 | grep -v HEAD`"
+          for branch in $branches
           do
             echo $branch
             git checkout $branch

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,34 +17,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       # Because ubuntu doxygen is currently outdated (v1.9 instead of v1.10)
-      - name: Install and run doxygen via Chocolatey
+      - name: Install doxygen and graphviz via Chocolatey
         run: |
-          choco install doxygen.portable graphviz --yes -r --no-progress
-          make docs
+        choco install doxygen.portable graphviz --yes -r --no-progress
+      - name: Build documentation for every branch
+        shell: bash
+        run: |
+          mkdir docs-output
+          for branch in $(git branch | cut -c 3-)
+          do
+            echo $branch
+            make clean
+            make docs
+            mv html docs-output/$branch
+          done
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'html/'
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Dry run
-        run: |
-          echo "Job deploy has been triggered successfully."
+        path: 'docs-output/'
       - name: Setup Pages
-        if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,7 +28,7 @@ jobs:
       # Because ubuntu doxygen is currently outdated (v1.9 instead of v1.10)
       - name: Install doxygen and graphviz via Chocolatey
         run: |
-        choco install doxygen.portable graphviz --yes -r --no-progress
+          choco install doxygen.portable graphviz --yes -r --no-progress
       - name: Build documentation for every branch
         shell: bash
         run: |
@@ -40,10 +40,12 @@ jobs:
             make docs
             mv html docs-output/$branch
           done
+          mv docs-output/main html
+          mv docs-output html/other-branches
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-        path: 'docs-output/'
+          path: 'html/'
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Deploy to GitHub Pages

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,26 +22,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # Because ubuntu doxygen is currently outdated (v1.9 instead of v1.10)
       - name: Install and run doxygen via Chocolatey
-      #- name: Run Doxygen
         run: |
           choco install doxygen.portable graphviz --yes -r --no-progress
           make docs
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'html/'
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    #runs-on: [self-hosted]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
     steps:
+      - name: Dry run
+        run: |
+          echo "Job deploy has been triggered successfully."
       - name: Setup Pages
+        if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'html/'
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean:
 # Windows only: open the generated documentation in the default browser.
 docs: Doxyfile
 	cp Doxyfile Doxyfile.temp
-	echo PROJECT_NUMBER = $$(git log -n1 --format="%h") >> Doxyfile.temp
+	echo PROJECT_NUMBER = $$(git branch --show-current) $$(git log -n1 --format="%h") >> Doxyfile.temp
 	doxygen Doxyfile.temp
 	@if [ "$(OS)" = "Windows_NT" ]; then \
 		start "html/index.html"; \


### PR DESCRIPTION
1. Documentation of other branches are accessible via
`https://eric15342335.github.io/comp2113-engg1340-group-project/other-branches/<branch name>`.

  * For example:
[`https://eric15342335.github.io/comp2113-engg1340-group-project/other-branches/pages-fix/`](https://eric15342335.github.io/comp2113-engg1340-group-project/other-branches/pages-fix/)
[`https://eric15342335.github.io/comp2113-engg1340-group-project/other-branches/develop/`](https://eric15342335.github.io/comp2113-engg1340-group-project/other-branches/develop/)

  * The [default link](https://eric15342335.github.io/comp2113-engg1340-group-project/) remains intact (for `main` branch).

2. Fix a bug in original `static.yml` file in `develop` branch as well.

3. Branch name before commit hash.
![image](https://github.com/eric15342335/comp2113-engg1340-group-project/assets/70310617/47850c29-4801-454e-9735-5f1efe547eed)


Note:
* Squash.