### PR TITLE
clang-tidy: Apply `clang-tidy` fixes and notes

### DIFF
--- a/include/controls.h
+++ b/include/controls.h
@@ -28,10 +28,11 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 void optionsInput(int row, int col, float & balance, float tax,
-    std::vector<Stock> & stocks, std::vector<Stock_event> events, bool & viewMode,
-    bool & advance, bool & overlayEvent, bool & gameQuit, bool & flush);
+    std::vector<Stock> & stocks, const std::vector<Stock_event> & events,
+    bool & viewMode, bool & advance, bool & overlayEvent, bool & flush,
+    bool & gameQuit);
 
-int integerInput(int row, int col, std::string message);
+int integerInput(int row, int col, const std::string & message);
 
 void buyStocks(int row, int col, float & balance, float tax,
     std::vector<Stock> & stocks, bool & flush);
@@ -43,6 +44,6 @@ void toggleView(bool & viewMode, bool & flush);
 
 void advanceConfirmation(int row, int col, bool & advance, bool & flush);
 
-void quitConfirmation(int row, int col, bool & gameQuit, bool & flush);
+void quitConfirmation(int row, int col, bool & flush, bool & gameQuit);
 
 #endif

--- a/include/events.h
+++ b/include/events.h
@@ -206,7 +206,7 @@ extern std::vector<Stock_event> all_stock_events;
  * @return A vector of Stock_event
  */
 std::vector<Stock_event> pick_events(
-    std::vector<Stock_event> all_events, unsigned int num_events);
+    const std::vector<Stock_event> & all_events, unsigned int num_events);
 
 /**
  * @brief If A is mutually exclusive with B, then B is mutually exclusive with A.
@@ -222,6 +222,6 @@ std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
 /** @brief Print a map to std::cout.
  * @param map The std::map object you want to print.
  */
-void print_map(std::map<unsigned int, std::vector<unsigned int>> map);
+void print_map(const std::map<unsigned int, std::vector<unsigned int>> & map);
 
 #endif

--- a/include/file_io.h
+++ b/include/file_io.h
@@ -36,7 +36,7 @@ void createplayer(std::string & playerName);
  * @param playerName The name of the player also the folder name
  */
 void savestatus(unsigned int rounds_played, std::vector<Stock> stocks_list,
-    float balance, std::string playerName);
+    float balance, const std::string & playerName);
 
 /**
  * @brief Load an existing game status from .save files. Paramenters should be empty and

--- a/include/random_price.h
+++ b/include/random_price.h
@@ -30,7 +30,7 @@ program. If not, see <https://www.gnu.org/licenses/>.
  * @param a the profile of the stock price
  * @return the initial stock price
  */
-float init_stock_price(int a);
+float init_stock_price(int price_profile);
 
 /**
  * @brief Initialize the standard deviation of the stock price

--- a/include/stock.h
+++ b/include/stock.h
@@ -54,14 +54,14 @@ class Stock {
          * @param playerName The name of the player.
          * @param i The index of the stock.
          */
-        void save(std::string playerName, int i);
+        void save(const std::string & playerName, int i);
 
         /**
          * @brief Load the stock from a file.
          * @param playerName The name of the player.
          * @param i The index of the stock.
          */
-        void load(std::string playerName, int i);
+        void load(const std::string & playerName, int i);
 
         /**
          * Purchase a given number of stocks.
@@ -90,13 +90,14 @@ class Stock {
          * @param trading_fees_percent The trading fees percentage we charge the player.
          * @return Number of stocks that the player can afford with the balance.
          */
-        unsigned int num_stocks_affordable(float balance, float trading_fees_percent);
+        unsigned int num_stocks_affordable(
+            float balance, float trading_fees_percent) const;
 
         /**
          * @brief Return the name of the category the stock belongs to.
          * @return Name of the category as a string.
          */
-        std::string category_name(void);
+        std::string category_name(void) const;
 
         /**
          * @brief Return the change of stock price using the most recent price and the
@@ -131,7 +132,7 @@ class Stock {
          * @param event The event to be added. See events.h for more information about
          * the class Stock_Event.
          */
-        void add_event(Stock_event event);
+        void add_event(const Stock_event & event);
 
         /**
          * @brief Get the stock price of recent rounds.
@@ -221,7 +222,7 @@ class Stock {
          * @param event The event to be added.
          * @return True if the event can be added. False otherwise.
          */
-        bool can_add_event(Stock_event event);
+        bool can_add_event(const Stock_event & event);
 
         /**
          * @brief Sums up get_attribute() and sum_attribute().

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -15,10 +15,11 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include "controls.h"
 
 void optionsInput(int row, int col, float & balance, float tax,
-    std::vector<Stock> & stocks, std::vector<Stock_event> events, bool & viewMode,
-    bool & advance, bool & overlayEvent, bool & flush, bool & gameQuit) {
+    std::vector<Stock> & stocks, const std::vector<Stock_event> & events,
+    bool & viewMode, bool & advance, bool & overlayEvent, bool & flush,
+    bool & gameQuit) {
     char input;
-    while (1) {
+    while (true) {
         std::cout << setCursorPosition(row, 3) << "\x1b[2K";
         std::cout << "Choose an option from the bar above: ";
         std::cin >> input;
@@ -38,11 +39,11 @@ void optionsInput(int row, int col, float & balance, float tax,
             case 'E':
             case 'e':
                 if (!overlayEvent) {
-                    overlayEvent = 1;
+                    overlayEvent = true;
                     listEvents(row, col, events);
                 }
                 else {
-                    flush = 1;
+                    flush = true;
                 }
                 break;
             case 'N':
@@ -67,10 +68,10 @@ void optionsInput(int row, int col, float & balance, float tax,
     }
 }
 
-int integerInput(int row, int col, std::string message) {
+int integerInput(int row, int col, const std::string & message) {
     std::ignore = col;
     int num;
-    while (1) {
+    while (true) {
         std::cout << setCursorPosition(row, 3) << "\x1b[2K";
         std::cout << message;
         std::cin >> num;
@@ -112,7 +113,7 @@ void buyStocks(int row, int col, float & balance, float tax,
         amount = integerInput(row, col, "Enter the amount to buy (0 to skip): ");
     }
     stocks[index - 1].purchase(balance, amount, tax);
-    flush = 1;
+    flush = true;
 }
 
 void sellStocks(int row, int col, float & balance, float tax,
@@ -141,12 +142,12 @@ void sellStocks(int row, int col, float & balance, float tax,
         amount = integerInput(row, col, "Enter the amount to sell (0 to skip): ");
     }
     stocks[index - 1].sell(balance, amount, tax);
-    flush = 1;
+    flush = true;
 }
 
 void toggleView(bool & viewMode, bool & flush) {
     viewMode = !viewMode;
-    flush = 1;
+    flush = true;
 }
 
 void advanceConfirmation(int row, int col, bool & advance, bool & flush) {
@@ -156,8 +157,8 @@ void advanceConfirmation(int row, int col, bool & advance, bool & flush) {
     std::cout << "Press [Y] to confirm: ";
     std::cin >> input;
     if (input == 'Y' || input == 'y') {
-        advance = 1;
-        flush = 1;
+        advance = true;
+        flush = true;
     }
 }
 
@@ -168,7 +169,7 @@ void quitConfirmation(int row, int col, bool & flush, bool & gameQuit) {
     std::cout << "Press [Y] to confirm: ";
     std::cin >> input;
     if (input == 'Y' || input == 'y') {
-        gameQuit = 1;
-        flush = 1;
+        gameQuit = true;
+        flush = true;
     }
 }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -138,7 +138,7 @@ void listEvents(int row, int col, std::vector<Stock_event> events) {
         for (int i = 1; i < (int)events.size() + 1; i++) {
             std::cout << setCursorPosition(i + 7, 11);
             std::cout << i << ". " << events[i - 1].text;
-            int digits = (int)(((i) / 10) + 1);
+            int digits = (((i) / 10) + 1);
             for (int j = 0; j < width - (int)events[i - 1].text.size() - 3 - digits;
                  j++) {
                 std::cout << " ";
@@ -159,7 +159,7 @@ void drawButton(int row, int col) {
         "[E] Events", "[N] Next Round", "[X] Exit"}; // Add stuff here
 
     buttons = options.size();
-    width = (int)(col / buttons);
+    width = (col / buttons);
 
     std::cout << textReset << setCursorPosition(row - 1, 3);
     for (int i = 0; i < buttons; i++) {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1068,8 +1068,8 @@ std::vector<Stock_event> all_stock_events = {
         {{standard_deviation, 0.5}, {mean, 7}, {lower_limit, 0}, {upper_limit, 20}}}};
 
 // print a map
-void print_map(std::map<unsigned int, std::vector<unsigned int>> map) {
-    for (auto i : map) {
+void print_map(const std::map<unsigned int, std::vector<unsigned int>> & map) {
+    for (const auto & i : map) {
         std::cout << i.first << ": ";
         for (unsigned int j : i.second) {
             std::cout << j << " ";
@@ -1107,7 +1107,7 @@ std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
     // Remove such two events from the map.
     // E.g. {0: [1,2], 1: [0], 2:[]} -> {0: [2]}
     // In this case, 2 does not state that it is mutually exclusive with 0.
-    for (auto i : mut_excl_map) {
+    for (const auto & i : mut_excl_map) {
         for (unsigned int j : i.second) {
             if (std::find(mut_excl_map[j].begin(), mut_excl_map[j].end(), i.first) !=
                 mut_excl_map[j].end()) {
@@ -1124,13 +1124,13 @@ std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
 }
 
 std::vector<Stock_event> pick_events(
-    std::vector<Stock_event> all_events, unsigned int num_events) {
+    const std::vector<Stock_event> & all_events, unsigned int num_events) {
     std::vector<Stock_event> picked_events;
     // Pick num_events random events
     for (unsigned int i = 0; i < num_events; i++) {
         // When picking the event, consider event.probability_permille.
         unsigned int total_permille = 0;
-        for (Stock_event event : all_events) {
+        for (const Stock_event & event : all_events) {
             total_permille += event.probability_permille;
         }
         /** E.g. if there are 3 events with probability_permille 10, 20, 30.
@@ -1141,7 +1141,7 @@ std::vector<Stock_event> pick_events(
          * If random_permille is 30 to 59, pick the third event.
          */
         unsigned int random_permille = random_integer(total_permille);
-        for (Stock_event event : all_events) {
+        for (const Stock_event & event : all_events) {
             total_permille -= event.probability_permille;
             if (total_permille <= random_permille) {
                 picked_events.emplace_back(event);

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -64,7 +64,7 @@ void createplayer(string & playerName) {
     cout << "Enter player name:" << endl;
     getline(cin, playerName);
     foldername = "saves/" + playerName;
-    while ((filesystem::exists(foldername) || playerName.find(" ") != string::npos) ||
+    while ((filesystem::exists(foldername) || playerName.find(' ') != string::npos) ||
            playerName.empty()) { // check whether file already exists
         if (!playerName.empty()) {
             cout << "Invalid Playername. ";
@@ -78,7 +78,7 @@ void createplayer(string & playerName) {
     filesystem::create_directory(foldername); // create a empty folder for new save
 }
 
-void load_hsi(std::vector<float> hsi_history, string playerName) {
+void load_hsi(std::vector<float> hsi_history, const string & playerName) {
     std::string filesave = "saves/" + playerName + "/hsi.save";
     std::ifstream fin;
     fin.open(filesave.c_str());
@@ -90,7 +90,7 @@ void load_hsi(std::vector<float> hsi_history, string playerName) {
 }
 
 void savestatus(unsigned int rounds_played, vector<Stock> stocks_list, float balance,
-    string playerName) {
+    const string & playerName) {
     string stocksave;
     ofstream fout;
     stocksave = "saves/" + playerName + "/playerstatus.save";
@@ -106,7 +106,8 @@ void savestatus(unsigned int rounds_played, vector<Stock> stocks_list, float bal
 
 void loadstatus(unsigned int & rounds_played, vector<Stock> & stocks_list,
     float & balance, string & playerName, vector<float> & hsi_history) {
-    string stockload, stockname;
+    string stockload;
+    string stockname;
     ifstream fin;
     vector<string> players;
     filesystem::create_directory("saves"); // prevent error when no folder exists
@@ -140,7 +141,10 @@ void loadstatus(unsigned int & rounds_played, vector<Stock> & stocks_list,
 }
 
 void delsave(string & mode) {
-    string stockdel, stockname, inputname, confirm;
+    string stockdel;
+    string stockname;
+    string inputname;
+    string confirm;
     ifstream fin;
     vector<string> players;
     filesystem::create_directory("saves"); // prevent error when no folder exists
@@ -196,7 +200,6 @@ void delsave(string & mode) {
     if (mode == "2") {
         delsave(mode);
     }
-    return;
 }
 
 vector<string> get_saves() {

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -21,6 +21,7 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <utility>
 #include <vector>
 using namespace std;
 
@@ -44,7 +45,7 @@ string graphpriceformat(float price) { // lock the max/min value between 6 chars
 }
 
 void printstocknameandoverall(
-    string stockname, vector<float> stockpricehistory, int stocknum) {
+    const string & stockname, vector<float> stockpricehistory, int stocknum) {
     string stocknameprint;
     if (stocknum != -1) {
         stocknameprint = "Stock: " + stockname;
@@ -86,7 +87,7 @@ void printvector(
 // will delete print in the final version
 
 vector<float> graphinput(
-    string player, int stocknum, string & stockname, unsigned int width) {
+    const string & player, int stocknum, string & stockname, unsigned int width) {
     string filename;
     if (stocknum != -1) {
         filename = "saves/" + player + "/" + to_string(stocknum) + ".save";
@@ -122,9 +123,11 @@ vector<float> graphinput(
 }
 
 void graph_plotting(string player, int stocknum, int width, int height) {
-    float max, min;
+    float max;
+    float min;
     string stockname;
-    vector<float> stockpricehistory = graphinput(player, stocknum, stockname, width);
+    vector<float> stockpricehistory =
+        graphinput(std::move(player), stocknum, stockname, width);
     // convert the raw log input into the nearest "width" data points
     vector<string> color(width - 9, "white");
     color[width - 10] = "white";
@@ -139,7 +142,8 @@ void graph_plotting(string player, int stocknum, int width, int height) {
     vector<vector<string>> graph(width, vector<string>(height, " "));
     // height column width rows, this is not in the usual 2d array format
     //  horizontal array and vertical array is inverted
-    string maxstring, minstring;
+    string maxstring;
+    string minstring;
     if (interval == 0) {
         maxstring = graphpriceformat(max + 1);
         minstring = graphpriceformat(min - 1);
@@ -156,7 +160,8 @@ void graph_plotting(string player, int stocknum, int width, int height) {
     // \DeclareUnicodeCharacter{2517}{\L}
 
     for (unsigned int i = 0; i < stockpricehistory.size() - 1; i++) {
-        int start = 10, end = 10;
+        int start = 10;
+        int end = 10;
         if (interval != 0) {
             start = (height - 1) - (stockpricehistory[i] - min) / interval;
             end = (height - 1) - (stockpricehistory[i + 1] - min) / interval;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ std::string playerName;
 
 std::string vectorToString(const std::vector<unsigned int> & vec) {
     return std::accumulate(
-        vec.begin(), vec.end(), std::string(), [](std::string s, int v) {
+        vec.begin(), vec.end(), std::string(), [](const std::string & s, int v) {
             return s.empty() ? std::to_string(v) : s + " " + std::to_string(v);
         });
 }
@@ -195,7 +195,7 @@ std::vector<Stock_event> get_ongoing_events(std::vector<Stock> stocks_list) {
     std::vector<Stock_event> ongoing_events = {};
     for (unsigned int i = 0; i < stocks_list.size(); i++) {
         std::list<Stock_event> events = stocks_list[i].get_events();
-        for (Stock_event event : events) {
+        for (const Stock_event & event : events) {
             // Side note: Events with duration <= 0 are automatically removed from the
             // stock's event list. By stock.cpp Stock::next_round() which uses
             // Stock::remove_obselete_event()
@@ -225,7 +225,7 @@ void new_events_next_round(std::vector<Stock> & stocks_list) {
         random_integer(2) +
         std::min(static_cast<int>(stocks_list[0].get_history_size() / 5), 2);
     std::vector<Stock_event> picked_events = pick_events(all_stock_events, numEvents);
-    for (Stock_event event : picked_events) {
+    for (const Stock_event & event : picked_events) {
         switch (event.type_of_event) {
             case all_stocks:
                 for (unsigned int i = 0; i < stocks_list.size(); i++) {
@@ -241,7 +241,7 @@ void new_events_next_round(std::vector<Stock> & stocks_list) {
                 break;
             case pick_random_stock: {
                 std::vector<unsigned int> stocks_indices_not_suitable = {};
-                while (stocks_list.size() > 0 &&
+                while (!stocks_list.empty() &&
                        stocks_list.size() < stocks_indices_not_suitable.size()) {
                     // Pick a random stock
                     unsigned int choice = random_integer(stocks_list.size());
@@ -281,17 +281,18 @@ int main(void) {
     std::cout << "The game was compiled on " << __DATE__ << " at " << __TIME__
               << std::endl;
 
-    bool advance;      // Whether to advance to the next round
-    bool gameQuit = 0; // Whether the player wants to quit the game
-    bool viewMode = 0; // 0 to view table, 1 to view graph
-    bool overlayEvent; // Whether the event bar is being shown
-    bool flush;        // Whether the screen needs updating
+    bool advance;          // Whether to advance to the next round
+    bool gameQuit = false; // Whether the player wants to quit the game
+    bool viewMode = false; // 0 to view table, 1 to view graph
+    bool overlayEvent;     // Whether the event bar is being shown
+    bool flush;            // Whether the screen needs updating
     int indexGraph;
     int row; // Number of characters to fit in a column
     int col; // Number of characters to fit in a row
     fetchConsoleDimensions(row, col);
 
     std::vector<Stock> stocks_list;
+    stocks_list.reserve(initial_stock_count);
     for (int i = 0; i < initial_stock_count; i++) {
         stocks_list.emplace_back(Stock()); // Add the stock to the vector
     }
@@ -305,7 +306,7 @@ int main(void) {
         check_mutual_exclusivity(all_stock_events);
     for (auto & [key, value] : checkEventResult) {
         // If the assertion is raised, print the checkEventResult and exit the program.
-        if (value.size() > 0) {
+        if (!value.empty()) {
             std::cout << "Error: detected mutual exclusivity violation! Details:"
                       << std::endl;
             print_map(checkEventResult);
@@ -349,9 +350,9 @@ int main(void) {
     time::sleep(sleepMedium * 2);
 
     while (!gameQuit) {
-        advance = 0;
-        overlayEvent = 0;
-        flush = 0;
+        advance = false;
+        overlayEvent = false;
+        flush = false;
         if (viewMode) {
             indexGraph =
                 integerInput(row, col, "Select stock index to display (0 for HSI): ");
@@ -384,7 +385,7 @@ int main(void) {
             next_round_routine(rounds_played, stocks_list);
             get_hsi(stocks_list, hsi_history);
             savestatus(rounds_played, stocks_list, balance, playerName);
-            viewMode = 0;
+            viewMode = false;
             time::sleep(sleepLong);
         }
     }

--- a/src/names.cpp
+++ b/src/names.cpp
@@ -60,10 +60,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -88,10 +90,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -113,10 +117,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -143,10 +149,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -172,10 +180,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -195,10 +205,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -219,10 +231,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -255,10 +269,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -295,10 +311,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -322,10 +340,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -344,10 +364,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -368,10 +390,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -396,10 +420,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -416,10 +442,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -438,10 +466,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -461,10 +491,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }
@@ -483,10 +515,12 @@ vector<string> generate_name(unsigned int category, unsigned int num) {
                     suffixes[uniform_int_distribution<int>(0, suffixes.size() - 1)(
                         gen)];
                 if (find(companyNames.begin(), companyNames.end(), name) ==
-                    companyNames.end())
+                    companyNames.end()) {
                     companyNames.emplace_back(name);
-                else
+                }
+                else {
                     i--;
+                }
             }
             break;
         }

--- a/src/stock.cpp
+++ b/src/stock.cpp
@@ -42,7 +42,7 @@ Stock::Stock(void) {
     update_history();
 }
 
-void Stock::save(std::string playerName, int i) {
+void Stock::save(const std::string & playerName, int i) {
     std::string filesave;
     std::ofstream fout;
     filesave = "saves/" + playerName + "/" + std::to_string(i) +
@@ -71,7 +71,7 @@ void Stock::save(std::string playerName, int i) {
     fout.close();
 }
 
-void Stock::load(std::string playerName, int i) {
+void Stock::load(const std::string & playerName, int i) {
     std::string fileToBeLoaded;
     float loadedPrice;
     std::ifstream fin;
@@ -164,9 +164,10 @@ float Stock::sell(float & balance, unsigned int amount, float trading_fees_perce
     return total_revenue;
 }
 
-std::string Stock::category_name(void) { return category_list[category]; }
+std::string Stock::category_name(void) const { return category_list[category]; }
 
-unsigned int Stock::num_stocks_affordable(float balance, float trading_fees_percent) {
+unsigned int Stock::num_stocks_affordable(
+    float balance, float trading_fees_percent) const {
     float value = balance / (price * (1 + trading_fees_percent));
     return value < 0 ? 0 : static_cast<unsigned int>(value);
 }
@@ -209,7 +210,7 @@ float Stock::delta_price_percentage(void) {
     return delta_price() / history[history.size() - 2];
 }
 
-void Stock::add_event(Stock_event event) {
+void Stock::add_event(const Stock_event & event) {
     if (!can_add_event(event)) {
         // If the event is mutually exclusive with ongoing events,
         // ignore it and do nothing.
@@ -230,10 +231,10 @@ void Stock::add_event(Stock_event event) {
     events.emplace_back(event);
 }
 
-bool Stock::can_add_event(Stock_event event) {
+bool Stock::can_add_event(const Stock_event & event) {
     std::list<Stock_event>::iterator event_itr = events.begin();
     while (event_itr != events.end()) {
-        if (event_itr->mutually_exclusive_events.size() > 0) {
+        if (!event_itr->mutually_exclusive_events.empty()) {
             for (unsigned int i = 0; i < event_itr->mutually_exclusive_events.size();
                  i++) {
                 if (event_itr->mutually_exclusive_events[i] == event.event_id) {


### PR DESCRIPTION
Command:
```bash
clang-tidy src/*.cpp --checks=performance-*,portability-*,readability-*,-performance-avoid-endl \
--fix-notes -- -Iinclude -std=c++17
```
and run `clang-format src/*.cpp include/*.h --verbose -i` after `clang-tidy`

Explanations:
* changing `pass by value` to `pass by reference (constant)` improves performance by avoiding copying
* change `1` to `true` to avoid implicit type conversion?
* split `string a,b,c;` into `string a; string b; string c;` for better `git diff` output in the future, also avoids `int *a, b;` confusion in the future