### PR TITLE
msvc: fix some cl.exe warnings

### DIFF
--- a/include/events.h
+++ b/include/events.h
@@ -129,7 +129,7 @@ struct Stock_event {
         unsigned int category;
 
         /** @brief Stores the stock_modifiers that the event applies. */
-        std::map<stock_modifiers, float> modifiers;
+        std::map<stock_modifiers, double> modifiers;
 
         /** @brief Overload the == operator to compare two Stock_event */
         bool operator==(const Stock_event & other) const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include <numeric>
 
 #ifdef _WIN32
-#define NOMINMAX 1 // Prevent Windows.h from defining min and max macros
+#define NOMINMAX 1          // Prevent Windows.h from defining min and max macros
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 /** @brief Enable Windows VT processing for ANSI escape codes
@@ -76,9 +76,9 @@ void get_hsi(std::vector<Stock> stocks_list, std::vector<float> & hsi_history) {
     std::string filesave = "saves/" + playerName + "/hsi.save";
     std::vector<float> total;
     for (unsigned int i = 0; i < stocks_list.size(); i++) {
-        total.emplace_back(stocks_list[i].get_price() /
-                           stocks_list[i].get_initial_price() * 1000 *
-                           static_cast<float>(std::pow(2, stocks_list[i].get_split_count())));
+        total.emplace_back(
+            stocks_list[i].get_price() / stocks_list[i].get_initial_price() * 1000 *
+            static_cast<float>(std::pow(2, stocks_list[i].get_split_count())));
         // HSI formula = (price/initial price) * 1000 * 2^split count
     }
     hsi = std::reduce(total.begin(), total.end()) / total.size();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,9 +27,9 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include <fstream>
 #include <numeric>
 
-#define NOMINMAX 1 // Prevent Windows.h from defining min and max macros
-
 #ifdef _WIN32
+#define NOMINMAX 1 // Prevent Windows.h from defining min and max macros
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 /** @brief Enable Windows VT processing for ANSI escape codes
  * @details Without this, ANSI escape codes will not work on Windows 10.
@@ -78,7 +78,7 @@ void get_hsi(std::vector<Stock> stocks_list, std::vector<float> & hsi_history) {
     for (unsigned int i = 0; i < stocks_list.size(); i++) {
         total.emplace_back(stocks_list[i].get_price() /
                            stocks_list[i].get_initial_price() * 1000 *
-                           pow(2, stocks_list[i].get_split_count()));
+                           static_cast<float>(std::pow(2, stocks_list[i].get_split_count())));
         // HSI formula = (price/initial price) * 1000 * 2^split count
     }
     hsi = std::reduce(total.begin(), total.end()) / total.size();


### PR DESCRIPTION
tho changing `float` to `double` kinda defeats the original purpose of reducing memory consumption
but i dont want to change every event `{standard_deviation, 0.1}` to `{standard_deviation, 0.1f}` 
which `0.1` is a double by standard, `0.1f` is a float