### PR TITLE
Makefile: Enable more compiler checks

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Make
       shell: bash
       run: |
-        echo -e "3" | make all
+        # Enabling optimization checks -Wmaybe-uninitialized from -Wall
+        echo -e "3" | FLAGS=-O2 make all
     - name: Set up Microsoft Dev Cmd
       if: matrix.os == 'windows-latest'
       uses: ilammy/msvc-dev-cmd@v1.13.0

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ check the code for formatting and static analysis issues
 
 CC = g++
 INCLUDES = -Iinclude
-FLAGS = -Wall -Wextra -pedantic -std=c++17 -Werror -g -O0 \
+FLAGS += -Wall -Wextra -pedantic -std=c++17 -Werror -g \
+    -Wcast-qual -Wundef -Wduplicated-cond -Wduplicated-branches \
     -mtune=native -Wswitch -Wshadow
+    # -Wconversion -Wfloat-equal
     # -D_FORTIFY_SOURCE=2 -fstack-protector-all -Og
     # -fsanitize=address -fsanitize=undefined
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ FLAGS += -Wall -Wextra -pedantic -std=c++17 -Werror -g \
     # -D_FORTIFY_SOURCE=2 -fstack-protector-all -Og
     # -fsanitize=address -fsanitize=undefined
 
+# macOS uses clang++, which does not support these flag:
+# -Wduplicated-cond -Wduplicated-branches
+ifeq ($(shell uname),Darwin)
+FLAGS += -Wno-unknown-warning-option
+endif
+
 # eric15342335 will use the static flag on Windows.
 ifeq ("$(OS)","Windows_NT")
 FLAGS += -static


### PR DESCRIPTION
`-Wconversion` is not enabled because we initialize `float` variables with `double` value, e.g. `float someValue = 0.1` instead of `float someValue = 0.1f`.

`-Wfloat-equal` is also not enabled as it seems to not affect anything yet. That warning exist in `graph.cpp` file