### PR TITLE
chore: Clean up duplicate user input prompt string of game saves

### DIFF
--- a/include/file_io.h
+++ b/include/file_io.h
@@ -23,7 +23,7 @@ class USER_SAVE_OPTION {
         static const std::string NEW_GAME;
         static const std::string LOAD_GAME;
         static const std::string DELETE_GAME;
-        static const std::string BACK;
+        static const std::string EXIT_GAME;
 };
 
 extern const std::string USER_SAVE_OPTION_PROMPT;
@@ -38,7 +38,7 @@ inline bool checkValidInput(const std::string & input) {
     return input.compare(USER_SAVE_OPTION::NEW_GAME) == 0 ||
            input.compare(USER_SAVE_OPTION::LOAD_GAME) == 0 ||
            input.compare(USER_SAVE_OPTION::DELETE_GAME) == 0 ||
-           input.compare(USER_SAVE_OPTION::BACK) == 0;
+           input.compare(USER_SAVE_OPTION::EXIT_GAME) == 0;
 }
 
 /**

--- a/include/file_io.h
+++ b/include/file_io.h
@@ -26,11 +26,7 @@ class USER_SAVE_OPTION {
         static const std::string BACK;
 };
 
-const std::string USER_SAVE_OPTION_PROMPT =
-    "Please enter.\n" + USER_SAVE_OPTION::NEW_GAME + " for new save,\n" +
-    USER_SAVE_OPTION::LOAD_GAME + " for loading old save(s),\n" +
-    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" + USER_SAVE_OPTION::BACK +
-    " to quit: ";
+extern const std::string USER_SAVE_OPTION_PROMPT;
 
 /**
  * @brief Check if the input is valid. The input is valid if it is one of the options

--- a/include/file_io.h
+++ b/include/file_io.h
@@ -47,7 +47,6 @@ const std::string SAVE_FOLDER_PREFIX = "saves/";
 // The extension of the save file, in plain text format
 const std::string SAVE_FILE_EXTENSION_TXT = ".save";
 
-
 /**
  * @brief returns the game logo, which is hardcoded inside the function.
  * @return a vector of strings, each string is a line of the logo

--- a/include/file_io.h
+++ b/include/file_io.h
@@ -17,10 +17,39 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #define FILE_IO_H
 #include "stock.h"
 
+/// @brief The user save options
+class USER_SAVE_OPTION {
+    public:
+        static const std::string NEW_GAME;
+        static const std::string LOAD_GAME;
+        static const std::string DELETE_GAME;
+        static const std::string BACK;
+};
+
+const std::string USER_SAVE_OPTION_PROMPT =
+    "Please enter.\n" + USER_SAVE_OPTION::NEW_GAME + " for new save,\n" +
+    USER_SAVE_OPTION::LOAD_GAME + " for loading old save(s),\n" +
+    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" + USER_SAVE_OPTION::BACK +
+    " to quit: ";
+
+/**
+ * @brief Check if the input is valid. The input is valid if it is one of the options
+ * in the USER_SAVE_OPTION class.
+ * @param input The input string
+ * @return true if the input is valid, false otherwise
+ */
+inline bool checkValidInput(const std::string & input) {
+    return input.compare(USER_SAVE_OPTION::NEW_GAME) == 0 ||
+           input.compare(USER_SAVE_OPTION::LOAD_GAME) == 0 ||
+           input.compare(USER_SAVE_OPTION::DELETE_GAME) == 0 ||
+           input.compare(USER_SAVE_OPTION::BACK) == 0;
+}
+
 /**
  * @brief returns the game logo, which is hardcoded inside the function.
+ * @return a vector of strings, each string is a line of the logo
  */
-std::vector<std::string> parseLogo();
+std::vector<std::string> parseLogo(void);
 
 /**
  * @brief Create a player folder.
@@ -61,7 +90,7 @@ void delsave(std::string & mode);
  * @brief Get the list of saves aka player folders.
  * @return a vector containing the name all the player folders
  */
-std::vector<std::string> get_saves();
+std::vector<std::string> get_saves(void);
 
 /**
  * @brief Print the vector of saves aka player folders.

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -25,6 +25,11 @@ const std::string USER_SAVE_OPTION::NEW_GAME = "0";
 const std::string USER_SAVE_OPTION::LOAD_GAME = "1";
 const std::string USER_SAVE_OPTION::DELETE_GAME = "2";
 const std::string USER_SAVE_OPTION::BACK = "3";
+const std::string USER_SAVE_OPTION_PROMPT =
+    "Please enter.\n" + USER_SAVE_OPTION::NEW_GAME + " for new save,\n" +
+    USER_SAVE_OPTION::LOAD_GAME + " for loading old save(s),\n" +
+    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" + USER_SAVE_OPTION::BACK +
+    " to quit: ";
 
 vector<string> parseLogo(void) {
     vector<string> logo;

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -21,6 +21,11 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include <iostream>
 using namespace std;
 
+const std::string USER_SAVE_OPTION::NEW_GAME = "0";
+const std::string USER_SAVE_OPTION::LOAD_GAME = "1";
+const std::string USER_SAVE_OPTION::DELETE_GAME = "2";
+const std::string USER_SAVE_OPTION::BACK = "3";
+
 vector<string> parseLogo() {
     vector<string> logo;
     // clang-format off
@@ -150,12 +155,13 @@ void delsave(string & mode) {
     filesystem::create_directory("saves"); // prevent error when no folder exists
     players = get_saves();                 // generate a vector of name of folders
     if (players.empty()) {
-        cout << "No player saves found, please enter 0 for new save or enter 3 to "
-                "quit: ";
+        cout << "No player saves found, please enter " << USER_SAVE_OPTION::NEW_GAME
+             << " for new save or enter " << USER_SAVE_OPTION::BACK << " to quit: ";
         std::cin >> mode;
-        while (mode != "0" && mode != "3") {
-            std::cout
-                << "Invalid input. Please enter 0 for new save or enter 3 to quit: ";
+        while (mode != USER_SAVE_OPTION::NEW_GAME && mode != USER_SAVE_OPTION::BACK) {
+            std::cout << "Invalid input. Please enter " + USER_SAVE_OPTION::NEW_GAME
+                      << " for new save or enter " + USER_SAVE_OPTION::BACK +
+                             " to quit: ";
             std::cin >> mode; // choose new file or load previous file
         }
         return;
@@ -189,20 +195,18 @@ void delsave(string & mode) {
     }
 
     // choosing mode again
-    std::cout << "Please enter 0 for new save, enter 1 for loading old save,\n enter 2 "
-                 "for deleting more save or enter 3 to quit: ";
+    std::cout << USER_SAVE_OPTION_PROMPT;
     std::cin >> mode;
-    while (mode != "0" && mode != "1" && mode != "2" && mode != "3") {
-        std::cout << "Invalid input. Please enter 0 for new save, enter 1 for loading "
-                     "old save, enter 2 for deleting more save or enter 3 to quit: ";
+    while (!checkValidInput(mode)) {
+        std::cout << "Invalid input. " + USER_SAVE_OPTION_PROMPT;
         std::cin >> mode; // choose new file or load previous file
     }
-    if (mode == "2") {
+    if (mode.compare(USER_SAVE_OPTION::DELETE_GAME) == 0) {
         delsave(mode);
     }
 }
 
-vector<string> get_saves() {
+vector<string> get_saves(void) {
     vector<string> saves;
     for (const auto & entry : std::filesystem::directory_iterator("saves")) {
         saves.emplace_back(entry.path().string().substr(6));
@@ -212,8 +216,8 @@ vector<string> get_saves() {
 
 void printvector(vector<string> avector) {
     cout << avector[0];
-    for (unsigned long i = 1; i < avector.size(); i++) {
-        cout << ", " << avector[i];
+    for (const auto & item : avector) {
+        cout << ", " << item;
     }
     cout << endl;
 }

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -26,7 +26,7 @@ const std::string USER_SAVE_OPTION::LOAD_GAME = "1";
 const std::string USER_SAVE_OPTION::DELETE_GAME = "2";
 const std::string USER_SAVE_OPTION::BACK = "3";
 
-vector<string> parseLogo() {
+vector<string> parseLogo(void) {
     vector<string> logo;
     // clang-format off
     logo.reserve(27);

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -24,11 +24,11 @@ using namespace std;
 const std::string USER_SAVE_OPTION::NEW_GAME = "0";
 const std::string USER_SAVE_OPTION::LOAD_GAME = "1";
 const std::string USER_SAVE_OPTION::DELETE_GAME = "2";
-const std::string USER_SAVE_OPTION::BACK = "3";
+const std::string USER_SAVE_OPTION::EXIT_GAME = "3";
 const std::string USER_SAVE_OPTION_PROMPT =
     "Please enter.\n" + USER_SAVE_OPTION::NEW_GAME + " for new save,\n" +
     USER_SAVE_OPTION::LOAD_GAME + " for loading old save(s),\n" +
-    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" + USER_SAVE_OPTION::BACK +
+    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" + USER_SAVE_OPTION::EXIT_GAME +
     " to quit: ";
 
 vector<string> parseLogo(void) {
@@ -161,11 +161,11 @@ void delsave(string & mode) {
     players = get_saves();                 // generate a vector of name of folders
     if (players.empty()) {
         cout << "No player saves found, please enter " << USER_SAVE_OPTION::NEW_GAME
-             << " for new save or enter " << USER_SAVE_OPTION::BACK << " to quit: ";
+             << " for new save or enter " << USER_SAVE_OPTION::EXIT_GAME << " to quit: ";
         std::cin >> mode;
-        while (mode != USER_SAVE_OPTION::NEW_GAME && mode != USER_SAVE_OPTION::BACK) {
+        while (mode != USER_SAVE_OPTION::NEW_GAME && mode != USER_SAVE_OPTION::EXIT_GAME) {
             std::cout << "Invalid input. Please enter " + USER_SAVE_OPTION::NEW_GAME
-                      << " for new save or enter " + USER_SAVE_OPTION::BACK +
+                      << " for new save or enter " + USER_SAVE_OPTION::EXIT_GAME +
                              " to quit: ";
             std::cin >> mode; // choose new file or load previous file
         }

--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -28,8 +28,8 @@ const std::string USER_SAVE_OPTION::EXIT_GAME = "3";
 const std::string USER_SAVE_OPTION_PROMPT =
     "Please enter.\n" + USER_SAVE_OPTION::NEW_GAME + " for new save,\n" +
     USER_SAVE_OPTION::LOAD_GAME + " for loading old save(s),\n" +
-    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" + USER_SAVE_OPTION::EXIT_GAME +
-    " to quit: ";
+    USER_SAVE_OPTION::DELETE_GAME + " for deleting save,\n" +
+    USER_SAVE_OPTION::EXIT_GAME + " to quit: ";
 
 vector<string> parseLogo(void) {
     vector<string> logo;
@@ -161,9 +161,11 @@ void delsave(string & mode) {
     players = get_saves();                 // generate a vector of name of folders
     if (players.empty()) {
         cout << "No player saves found, please enter " << USER_SAVE_OPTION::NEW_GAME
-             << " for new save or enter " << USER_SAVE_OPTION::EXIT_GAME << " to quit: ";
+             << " for new save or enter " << USER_SAVE_OPTION::EXIT_GAME
+             << " to quit: ";
         std::cin >> mode;
-        while (mode != USER_SAVE_OPTION::NEW_GAME && mode != USER_SAVE_OPTION::EXIT_GAME) {
+        while (
+            mode != USER_SAVE_OPTION::NEW_GAME && mode != USER_SAVE_OPTION::EXIT_GAME) {
             std::cout << "Invalid input. Please enter " + USER_SAVE_OPTION::NEW_GAME
                       << " for new save or enter " + USER_SAVE_OPTION::EXIT_GAME +
                              " to quit: ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,7 +336,7 @@ int main(void) {
         if (loadsave.compare(USER_SAVE_OPTION::DELETE_GAME) == 0) {
             delsave(loadsave); // delete existing file
         }
-        if (loadsave.compare(USER_SAVE_OPTION::BACK) == 0) {
+        if (loadsave.compare(USER_SAVE_OPTION::EXIT_GAME) == 0) {
             std::cout << "Goodbye! Hope you had a good luck in the stock market!"
                       << std::endl;
             return EXIT_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,6 +328,7 @@ int main(void) {
         }
         if (loadsave.compare(USER_SAVE_OPTION::NEW_GAME) == 0) {
             createplayer(playerName);
+            savestatus(rounds_played, stocks_list, balance, playerName);
         }
         if (loadsave.compare(USER_SAVE_OPTION::LOAD_GAME) == 0) {
             loadstatus(rounds_played, stocks_list, balance, playerName, hsi_history);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,37 +317,31 @@ int main(void) {
     time::sleep(sleepMedium);
     std::vector<float> hsi_history;
     get_hsi(stocks_list, hsi_history);
+
     {
         std::string loadsave;
-        std::cout << "Please enter.\n0 for new save,\n1 for loading old save(s),\n2 "
-                     "for deleting save,\n3 to quit: ";
+        std::cout << USER_SAVE_OPTION_PROMPT;
         std::cin >> loadsave;
-        while (
-            loadsave != "0" && loadsave != "1" && loadsave != "2" && loadsave != "3") {
-            std::cout
-                << "Invalid input.\nPlease enter.\n0 for new save,\n1 for loading "
-                   "old save(s),\n2 for deleting save,\n3 to quit:"
-                << std::endl;
+        while (!checkValidInput(loadsave)) {
+            std::cout << "Invalid input.\n" << USER_SAVE_OPTION_PROMPT;
             std::cin >> loadsave; // choose new file or load previous file
         }
-        if (loadsave == "1") {
+        if (loadsave.compare(USER_SAVE_OPTION::NEW_GAME) == 0) {
+            createplayer(playerName);
+        }
+        if (loadsave.compare(USER_SAVE_OPTION::LOAD_GAME) == 0) {
             loadstatus(rounds_played, stocks_list, balance, playerName, hsi_history);
         }
-        if (loadsave == "2") {
+        if (loadsave.compare(USER_SAVE_OPTION::DELETE_GAME) == 0) {
             delsave(loadsave); // delete existing file
         }
-        if (loadsave == "3") {
+        if (loadsave.compare(USER_SAVE_OPTION::DELETE_GAME) == 0) {
             std::cout << "Goodbye! Hope you had a good luck in the stock market!"
                       << std::endl;
             return 0;
         }
-        if (loadsave == "0") {
-            createplayer(playerName);
-            savestatus(rounds_played, stocks_list, balance, playerName);
-        }
-        // Done loading/creating a new file.
     }
-
+    // Done loading/creating a new file.
     std::cout << "Current trading fees are charged at " << trading_fees_percent * 100
               << " %" << std::endl;
     time::sleep(sleepMedium * 2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,10 +336,10 @@ int main(void) {
         if (loadsave.compare(USER_SAVE_OPTION::DELETE_GAME) == 0) {
             delsave(loadsave); // delete existing file
         }
-        if (loadsave.compare(USER_SAVE_OPTION::DELETE_GAME) == 0) {
+        if (loadsave.compare(USER_SAVE_OPTION::BACK) == 0) {
             std::cout << "Goodbye! Hope you had a good luck in the stock market!"
                       << std::endl;
-            return 0;
+            return EXIT_SUCCESS;
         }
     }
     // Done loading/creating a new file.


### PR DESCRIPTION
File I/O:
* `file_io.cpp` 192-197 has duplicate strings (that appears on `main.cpp` too) which can be converted into a `const string` global variable `USER_SAVE_OPTION_PROMPT` stored in `file_io.h`

* Define user game save input option globally in `USER_SAVE_OPTION` class to improve maintainability

UI/UX:
* Fix inconsistency of newline `\n` character found between `main.cpp` and `file_io.cpp` user input prompt string
