### PR TITLE
main: Simplify complexity by converting event mutual exclusivity checks into a function

### DIFF
--- a/include/events.h
+++ b/include/events.h
@@ -223,7 +223,7 @@ std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
  * @brief Check if there are mutual exclusivity violations in all_stock_events.
  * @return True if the events are mutually exclusive with each other.
  */
-bool inline assertion_check_mutual_exclusivity(void);
+bool assertion_check_mutual_exclusivity(void);
 
 /** @brief Print a map to std::cout.
  * @param map The std::map object you want to print.

--- a/include/events.h
+++ b/include/events.h
@@ -197,7 +197,7 @@ struct Stock_event {
 };
 
 /** @brief The list of all events that will be applied to the stocks. */
-extern std::vector<Stock_event> all_stock_events;
+extern const std::vector<Stock_event> all_stock_events;
 
 /**
  * @brief Pick a random event from the list of events
@@ -217,7 +217,13 @@ std::vector<Stock_event> pick_events(
  * exist but should.
  */
 std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
-    std::vector<Stock_event> all_events);
+    const std::vector<Stock_event> & all_events);
+
+/**
+ * @brief Check if there are mutual exclusivity violations in all_stock_events.
+ * @return True if the events are mutually exclusive with each other.
+ */
+bool inline assertion_check_mutual_exclusivity(void);
 
 /** @brief Print a map to std::cout.
  * @param map The std::map object you want to print.

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -45,7 +45,7 @@ program. If not, see <https://www.gnu.org/licenses/>.
  * | 86 to 91       | Telecom           |
  * | 92 to 98       | pick_random_stock |
  */
-std::vector<Stock_event> all_stock_events = {
+const std::vector<Stock_event> all_stock_events = {
     // event_id 0 to 7 affect all stocks
     {/** event_id */ 0,
         /** mutually_exclusive_events */ {1},
@@ -1093,7 +1093,7 @@ int main() {
 */
 
 std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
-    std::vector<Stock_event> all_events) {
+    const std::vector<Stock_event> & all_events) {
     std::map<unsigned int, std::vector<unsigned int>> mut_excl_map;
     // Build the map
     for (unsigned int i = 0; i < all_events.size(); i++) {
@@ -1121,6 +1121,22 @@ std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
         }
     }
     return mut_excl_map;
+}
+
+bool inline assertion_check_mutual_exclusivity(void) {
+    // Assert that the every key has no value.
+    auto checkEventResult = check_mutual_exclusivity(all_stock_events);
+    for (const auto & [key, value] : checkEventResult) {
+        // If the assertion is raised, print the checkEventResult and exit the
+        // program.
+        if (!value.empty()) {
+            std::cout << "Error: detected mutual exclusivity violation! Details:"
+                      << std::endl;
+            print_map(checkEventResult);
+            return true;
+        }
+    }
+    return false;
 }
 
 std::vector<Stock_event> pick_events(

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1123,7 +1123,7 @@ std::map<unsigned int, std::vector<unsigned int>> check_mutual_exclusivity(
     return mut_excl_map;
 }
 
-bool inline assertion_check_mutual_exclusivity(void) {
+bool assertion_check_mutual_exclusivity(void) {
     // Assert that the every key has no value.
     auto checkEventResult = check_mutual_exclusivity(all_stock_events);
     for (const auto & [key, value] : checkEventResult) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -298,21 +298,11 @@ int main(void) {
 
     sortStocksList(stocks_list, by_category, ascending);
 
-    {
-        // Assert that the every key has no value.
-        std::map<unsigned int, std::vector<unsigned int>> checkEventResult =
-            check_mutual_exclusivity(all_stock_events);
-        for (auto & [key, value] : checkEventResult) {
-            // If the assertion is raised, print the checkEventResult and exit the
-            // program.
-            if (!value.empty()) {
-                std::cout << "Error: detected mutual exclusivity violation! Details:"
-                          << std::endl;
-                print_map(checkEventResult);
-                return 1;
-            }
-        }
+    // Check if the events are mutually exclusive
+    if (assertion_check_mutual_exclusivity()) {
+        exit(1);
     }
+
     drawLogo(row, col);
     time::sleep(sleepMedium);
     std::vector<float> hsi_history;


### PR DESCRIPTION
Move code into events.cpp and prototype in header

exit(1) instead of return 1

Declare as inline function

Constant-ize all_stock_events vector