### PR TITLE
Graph: Refactor `printvector()` to improve readability and avoid name collision

### DIFF
--- a/include/graph.h
+++ b/include/graph.h
@@ -39,6 +39,7 @@ void graph_plotting(const std::string & player, int stocknum, int width, int hei
  * @param height The height of the screen.
  */
 void printgraphblocks(const std::vector<std::vector<std::string>> & screenElements,
-    const std::vector<std::string> & specifiedColorCoordinates, const int width, const int height);
+    const std::vector<std::string> & specifiedColorCoordinates, const int width,
+    const int height);
 
 #endif

--- a/include/graph.h
+++ b/include/graph.h
@@ -16,6 +16,7 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef GRAPH_H
 #define GRAPH_H
 #include <string>
+#include <vector>
 
 /** @brief Plot the graph of the stock price history to std::cout.
  * @param player the name of the player
@@ -24,5 +25,20 @@ program. If not, see <https://www.gnu.org/licenses/>.
  * @param height the height of the graph
  */
 void graph_plotting(const std::string & player, int stocknum, int width, int height);
+
+/**
+ * @brief Prints the graph blocks on the screen.
+ *
+ * This function takes in a 2D vector of screen elements, a vector of specified color
+ * coordinates, the width and height of the screen, and prints the graph blocks on the
+ * screen based on the given elements and coordinates.
+ *
+ * @param screenElements A 2D vector of screen elements.
+ * @param specifiedColorCoordinates A vector of specified color coordinates.
+ * @param width The width of the screen.
+ * @param height The height of the screen.
+ */
+void printgraphblocks(const std::vector<std::vector<std::string>> & screenElements,
+    const std::vector<std::string> & specifiedColorCoordinates, const int width, const int height);
 
 #endif

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -15,8 +15,9 @@ program. If not, see <https://www.gnu.org/licenses/>.
 // This file should be saved in UTF-8 with BOM encoding
 // to display the unicode characters correctly.
 #include "graph.h"
-#include "format.h"
+
 #include "file_io.h"
+#include "format.h"
 
 #include <algorithm>
 #include <cassert>

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -19,11 +19,11 @@ program. If not, see <https://www.gnu.org/licenses/>.
 #include "format.h"
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <cassert>
 using namespace std;
 
 string graphpriceformat(float price) {
@@ -64,10 +64,14 @@ void printstocknameandoverall(
 }
 
 void printgraphblocks(const vector<vector<string>> & screenElements,
-    const vector<string> & specifiedColorCoordinates, const int width, const int height) {
-    // Boundary check of width and height, otherwise may access screenElements out of bounds
-    assert(width <= static_cast<int>(screenElements.size()) && "Width exceeds screenElements width");
-    assert(height <= static_cast<int>(screenElements[0].size()) && "Height exceeds screenElements height");
+    const vector<string> & specifiedColorCoordinates, const int width,
+    const int height) {
+    // Boundary check of width and height, otherwise may access screenElements out of
+    // bounds
+    assert(width <= static_cast<int>(screenElements.size()) &&
+           "Width exceeds screenElements width");
+    assert(height <= static_cast<int>(screenElements[0].size()) &&
+           "Height exceeds screenElements height");
     int colorIndex;
     for (int heightIndex = 0; heightIndex < height; heightIndex++) {
         for (int widthIndex = 0; widthIndex < width; widthIndex++) {


### PR DESCRIPTION
* Rename `printvector()` to `printgraphblocks()`
  * you get the joke right? I am trying mimic @comet13579 naming style (which is `freestyle` as @Prismatiscence mentioned! xD)
* Rename local variables name `vectorname` to `screenElements`
* Rename color to `specifiedColorCoordinates`
* Try replacing `\033` to `const` color values in `format.h`
* Prototype function in `graph.h`
* Replace magic values green red white with `textGreen` `textRed` `textDefault`
* Add an assertion that`height` and `width` does not match 2D vector size, potentially causing `undefined behavior`