### PR TITLE
chore: Update Makefile to include git pull in the fix target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ docs: Doxyfile src/*.cpp include/*.h
 	rm Doxyfile.temp
 
 fix:
+	git pull
 	clang-format --verbose -i src/*.cpp include/*.h
 	git commit -a -m "Formatting: Run clang-format" -m "From Makefile: make fix"
 	git push


### PR DESCRIPTION
AI generated:
* This commit updates the Makefile to include a `git pull` command in the `fix` target. This ensures that the latest changes from the remote repository are pulled before running `clang-format` on the source files. The purpose of this change is to ensure that the code formatting is consistent with the latest changes in the repository.